### PR TITLE
Create a shared informer to watch the CRDs

### DIFF
--- a/create.go
+++ b/create.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-openapi/spec"
@@ -18,9 +16,6 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func createCRDsForResources(provider *plugin.GRPCProvider) {
@@ -136,25 +131,6 @@ func getSchemaForType(name string, item *cty.Type) *spec.Schema {
 }
 
 // k8s stuff
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
-}
-
-func getK8sClientConfig() *rest.Config {
-	home := homeDir()
-
-	// use the current context in kubeconfig
-	clientConfig, err := clientcmd.BuildConfigFromFlags("", filepath.Join(home, ".kube", "config"))
-	if err != nil {
-		panic(err.Error())
-	}
-
-	return clientConfig
-}
-
 func installCRDs(resources []spec.Schema, providerName, providerVersion string) {
 	clientConfig := getK8sClientConfig()
 
@@ -215,44 +191,6 @@ func createCustomResourceDefinition(namespace string, clientSet apiextensionscli
 
 		return nil, err
 	}
-
-	// // Wait for CRD creation.
-	// // Todo: Not sure if this is necesssary
-	// err = wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
-	// 	crd, err = clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
-	// 	if err != nil {
-	// 		fmt.Printf("Fail to wait for CRD creation: %+v\n", err)
-
-	// 		return false, err
-	// 	}
-	// 	for _, cond := range crd.Status.Conditions {
-	// 		switch cond.Type {
-	// 		case apiextensionsv1beta1.Established:
-	// 			if cond.Status == apiextensionsv1beta1.ConditionTrue {
-	// 				return true, err
-	// 			}
-	// 		case apiextensionsv1beta1.NamesAccepted:
-	// 			if cond.Status == apiextensionsv1beta1.ConditionFalse {
-	// 				fmt.Printf("Name conflict while wait for CRD creation: %s, %+v\n", cond.Reason, err)
-	// 			}
-	// 		}
-	// 	}
-
-	// 	return false, err
-	// })
-
-	// // If there is an error, delete the object to keep it clean.
-	// if err != nil {
-	// 	fmt.Println("Try to cleanup")
-	// 	deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
-	// 	if deleteErr != nil {
-	// 		fmt.Printf("Fail to delete CRD: %+v\n", deleteErr)
-
-	// 		return nil, errors.NewAggregate([]error{err, deleteErr})
-	// 	}
-
-	// 	return nil, err
-	// }
 
 	return crd, nil
 }

--- a/create.go
+++ b/create.go
@@ -3,13 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/go-openapi/spec"
 	"github.com/hashicorp/terraform/configs/configschema"
@@ -20,9 +18,8 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -146,19 +143,20 @@ func homeDir() string {
 	return os.Getenv("USERPROFILE") // windows
 }
 
-func installCRDs(resources []spec.Schema, providerName, providerVersion string) {
-	var kubeconfig *string
-	if home := homeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
+func getK8sClientConfig() *rest.Config {
+	home := homeDir()
 
 	// use the current context in kubeconfig
-	clientConfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	clientConfig, err := clientcmd.BuildConfigFromFlags("", filepath.Join(home, ".kube", "config"))
 	if err != nil {
 		panic(err.Error())
 	}
+
+	return clientConfig
+}
+
+func installCRDs(resources []spec.Schema, providerName, providerVersion string) {
+	clientConfig := getK8sClientConfig()
 
 	// create the clientset
 	apiextensionsClientSet, err := apiextensionsclientset.NewForConfig(clientConfig)
@@ -218,43 +216,43 @@ func createCustomResourceDefinition(namespace string, clientSet apiextensionscli
 		return nil, err
 	}
 
-	// Wait for CRD creation.
-	// Todo: Not sure if this is necesssary
-	err = wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
-		crd, err = clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
-		if err != nil {
-			fmt.Printf("Fail to wait for CRD creation: %+v\n", err)
+	// // Wait for CRD creation.
+	// // Todo: Not sure if this is necesssary
+	// err = wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
+	// 	crd, err = clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	// 	if err != nil {
+	// 		fmt.Printf("Fail to wait for CRD creation: %+v\n", err)
 
-			return false, err
-		}
-		for _, cond := range crd.Status.Conditions {
-			switch cond.Type {
-			case apiextensionsv1beta1.Established:
-				if cond.Status == apiextensionsv1beta1.ConditionTrue {
-					return true, err
-				}
-			case apiextensionsv1beta1.NamesAccepted:
-				if cond.Status == apiextensionsv1beta1.ConditionFalse {
-					fmt.Printf("Name conflict while wait for CRD creation: %s, %+v\n", cond.Reason, err)
-				}
-			}
-		}
+	// 		return false, err
+	// 	}
+	// 	for _, cond := range crd.Status.Conditions {
+	// 		switch cond.Type {
+	// 		case apiextensionsv1beta1.Established:
+	// 			if cond.Status == apiextensionsv1beta1.ConditionTrue {
+	// 				return true, err
+	// 			}
+	// 		case apiextensionsv1beta1.NamesAccepted:
+	// 			if cond.Status == apiextensionsv1beta1.ConditionFalse {
+	// 				fmt.Printf("Name conflict while wait for CRD creation: %s, %+v\n", cond.Reason, err)
+	// 			}
+	// 		}
+	// 	}
 
-		return false, err
-	})
+	// 	return false, err
+	// })
 
-	// If there is an error, delete the object to keep it clean.
-	if err != nil {
-		fmt.Println("Try to cleanup")
-		deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
-		if deleteErr != nil {
-			fmt.Printf("Fail to delete CRD: %+v\n", deleteErr)
+	// // If there is an error, delete the object to keep it clean.
+	// if err != nil {
+	// 	fmt.Println("Try to cleanup")
+	// 	deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
+	// 	if deleteErr != nil {
+	// 		fmt.Printf("Fail to delete CRD: %+v\n", deleteErr)
 
-			return nil, errors.NewAggregate([]error{err, deleteErr})
-		}
+	// 		return nil, errors.NewAggregate([]error{err, deleteErr})
+	// 	}
 
-		return nil, err
-	}
+	// 	return nil, err
+	// }
 
 	return crd, nil
 }

--- a/examples/resourceGroup.yaml
+++ b/examples/resourceGroup.yaml
@@ -1,8 +1,8 @@
-apiVersion: "azurerm.tfb/v0"
+apiVersion: azurerm.tfb.local/valpha1
 kind: resource-group
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: crontabs.stable.example.com
+  name: test1rg
   namespace: default
 spec:
   location: northEurope

--- a/informer.go
+++ b/informer.go
@@ -32,18 +32,16 @@ func startSharedInformer() {
 	informer := informerGeneric.Informer()
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		// When a new pod gets created
+		// When a new resource gets created
 		AddFunc: func(obj interface{}) {
 
 			resource := obj.(*unstructured.Unstructured)
 
 			log.Println(resource)
-
-			// panic("not implemented")
 		},
-		// When a pod gets updated
+		// When a pod resource updated
 		UpdateFunc: func(interface{}, interface{}) { panic("not implemented") },
-		// When a pod gets deleted
+		// When a pod resource deleted
 		DeleteFunc: func(interface{}) { panic("not implemented") },
 	})
 

--- a/informer.go
+++ b/informer.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+)
+
+func startSharedInformer() {
+	clientConfig := getK8sClientConfig()
+
+	clientSet, err := dynamic.NewForConfig(clientConfig)
+	if err != nil {
+		log.Panicln(err)
+		panic("Failed to create k8s client set")
+	}
+
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(clientSet, time.Minute*5)
+
+	// Todo: Register informers for all the resources... Ideally one single informer for all in group `azurerm.tfb.local`
+	informerGeneric := factory.ForResource(schema.GroupVersionResource{
+		Group:    "azurerm.tfb.local",
+		Version:  "valpha1",
+		Resource: "resource-groups",
+	})
+
+	informer := informerGeneric.Informer()
+
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		// When a new pod gets created
+		AddFunc: func(obj interface{}) {
+
+			resource := obj.(*unstructured.Unstructured)
+
+			log.Println(resource)
+
+			// panic("not implemented")
+		},
+		// When a pod gets updated
+		UpdateFunc: func(interface{}, interface{}) { panic("not implemented") },
+		// When a pod gets deleted
+		DeleteFunc: func(interface{}) { panic("not implemented") },
+	})
+
+	stopCh := make(chan struct{}, 1)
+	informer.Run(stopCh)
+
+}

--- a/main.go
+++ b/main.go
@@ -14,8 +14,10 @@ func main() {
 	useProviderToTalkToAzure(provider)
 
 	// Example creating CRDs in K8s with correct structure based on TF Schemas
-	// createCRDsForResources(provider)
+	createCRDsForResources(provider)
 
+	// Start an informer to watch for crd items
+	startSharedInformer()
 }
 
 func getInstanceOfAzureRMProvider() *plugin.GRPCProvider {


### PR DESCRIPTION
This creates a dynamic informer which is able to watch the CRD types without go structs defined for their structure. 

When a CRD for `resource-group` is added the following data is logged:

`
2020/07/09 07:04:56 &{map[apiVersion:azurerm.tfb.local/valpha1 kind:resource-group metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"azurerm.tfb.local/valpha1","kind":"resource-group","metadata":{"annotations":{},"name":"test1rg","namespace":"default"},"spec":{"location":"northEurope","name":"test1"}}
`

I refactor some of `create.go` to reuse the kubeconfig discovery and speed up the CRD creation.