### PR TITLE
Hook up informer to reconciler

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,13 +15,14 @@ func main() {
 	provider := getInstanceOfAzureRMProvider()
 
 	// Example talking to the Azure resources using the provider
-	useProviderToTalkToAzure(provider)
+	configureProvider(provider)
+	// exampleChangesToResourceGroup(provider)
 
 	// Example creating CRDs in K8s with correct structure based on TF Schemas
-	createCRDsForResources(provider)
+	go createCRDsForResources(provider)
 
 	// Start an informer to watch for crd items
-	startSharedInformer()
+	startSharedInformer(provider)
 }
 
 func getInstanceOfAzureRMProvider() *plugin.GRPCProvider {


### PR DESCRIPTION
This hooks up the work from @stuartleeks in #2 with the work in #1. The end result is that we will be able to reconcile changes in the CRD Spec to the Azure Resource.

Currently it can create a new resource group as specified in the `./examples/resourceGroup.yaml` 

Todo:
- [ ] Currently missing state persistence
- [ ] Handle delete