### PR TITLE
Move towards integration tests via CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 
-run: kind-create
+run: kind-create terraform-hack-init
 	go run .
 
 kind-create:
 	@echo "Create cluster if doesn't exist"
-	-kind create cluster --name tob
-	kind export kubeconfig --name tob
+	./scripts/init-kind-cluster.sh
+
+terraform-hack-init:
+	./hack/init.sh

--- a/create.go
+++ b/create.go
@@ -64,6 +64,7 @@ func createCRDsForResources(provider *plugin.GRPCProvider) {
 	// Install all of the resources as CRDs into the cluster
 	installCRDs(resources, "azurerm", fmt.Sprintf("v%v", "alpha1"))
 
+	fmt.Printf("Creating CRDs - Done")
 }
 
 // This walks the schema and adds the fields to spec/status based on whether they're computed or not.

--- a/create.go
+++ b/create.go
@@ -181,13 +181,15 @@ func installCRDs(resources []spec.Schema, providerName, providerVersion string) 
 }
 
 func createCustomResourceDefinition(namespace string, clientSet apiextensionsclientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+	crdName := crd.ObjectMeta.Name
+	fmt.Printf("Creating CRD %q... ", crdName)
 	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
 	if err == nil {
-		fmt.Println("CRD created")
+		fmt.Println("created")
 	} else if apierrors.IsAlreadyExists(err) {
-		fmt.Println("CRD already exists")
+		fmt.Println("already exists")
 	} else {
-		fmt.Printf("Fail to create CRD: %+v\n", err)
+		fmt.Printf("Failed: %+v\n", err)
 
 		return nil, err
 	}

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT=$(readlink -f $0)
+BASE_DIR=`dirname ${SCRIPT}`
+
+pushd "$BASE_DIR"
+
+terraform init

--- a/informer.go
+++ b/informer.go
@@ -52,8 +52,15 @@ func startSharedInformer(provider *plugin.GRPCProvider) {
 		},
 		// When a pod resource updated
 		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+			oldResource := oldObj.(*unstructured.Unstructured)
+			oldGen := oldResource.GetGeneration()
 			resource := newObj.(*unstructured.Unstructured)
+			gen := resource.GetGeneration()
 			log.Printf("*** Handling Add: Namespace=%s; Kind=%s; Name=%s\n", resource.GetNamespace(), resource.GetKind(), resource.GetName())
+			if oldGen == gen {
+				log.Printf("Generation hasn't changed (%d) - skipping event\n", gen)
+				return
+			}
 			reconcileCrd(provider, resource.GetKind(), resource)
 
 			gvr := resource.GroupVersionKind().GroupVersion().WithResource(resource.GetKind() + "s") // TODO - look at a better way of getting this!

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	if skipcreation {
 		fmt.Println("SKIP_CRD_CREATION set - skipping CRD creation")
 	} else {
-		go createCRDsForResources(provider)
+		createCRDsForResources(provider)
 	}
 
 	// Start an informer to watch for crd items

--- a/main.go
+++ b/main.go
@@ -19,7 +19,12 @@ func main() {
 	// exampleChangesToResourceGroup(provider)
 
 	// Example creating CRDs in K8s with correct structure based on TF Schemas
-	go createCRDsForResources(provider)
+	_, skipcreation := os.LookupEnv("SKIP_CRD_CREATION")
+	if skipcreation {
+		fmt.Println("SKIP_CRD_CREATION set - skipping CRD creation")
+	} else {
+		go createCRDsForResources(provider)
+	}
 
 	// Start an informer to watch for crd items
 	startSharedInformer(provider)

--- a/reconcile.go
+++ b/reconcile.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -123,6 +124,8 @@ func reconcileCrd(provider *plugin.GRPCProvider, kind string, crd *unstructured.
 	newState := planAndApplyConfig(provider, resourceName, *configValue, []byte(state))
 
 	annotations["tfstate"] = base64.StdEncoding.EncodeToString(newState)
+	gen := crd.GetGeneration()
+	annotations["lastAppliedGeneration"] = strconv.FormatInt(gen, 10)
 	crd.SetAnnotations(annotations)
 }
 

--- a/scripts/init-kind-cluster.sh
+++ b/scripts/init-kind-cluster.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+CLUSTER_NAME="tob"
+CLUSTER_EXISTS=$(kind get clusters | grep -q -o "^$CLUSTER_NAME\$" ; echo $?)
+if [[ $CLUSTER_EXISTS == "0" ]]; then
+    echo "Cluster '$CLUSTER_NAME' already exists"
+else
+    echo "Creating cluster '$CLUSTER_NAME' ..."
+    kind create cluster --name tob
+fi
+kind export kubeconfig --name tob

--- a/test/resourcegroup-tfbtest1-1.yml
+++ b/test/resourcegroup-tfbtest1-1.yml
@@ -1,0 +1,10 @@
+# initial tfbtest1 definition
+apiVersion: azurerm.tfb.local/valpha1
+kind: resource-group
+metadata:
+  name: test1
+spec:
+  name: tfbtest1
+  location: westeurope
+  tags:
+    tag1: Value1

--- a/test/resourcegroup-tfbtest1-2.yml
+++ b/test/resourcegroup-tfbtest1-2.yml
@@ -1,0 +1,11 @@
+# updated tfbtest1 definition
+apiVersion: azurerm.tfb.local/valpha1
+kind: resource-group
+metadata:
+  name: test1
+spec:
+  name: tfbtest1
+  location: westeurope
+  tags:
+    tag1: Value1
+    tag2: Another Value


### PR DESCRIPTION
~~**NOTE - currently this code causes an endless cycle of updates!**~~

Apologies for the large batch of changes!

Changes
* Add script for kind cluster init - avoid "cluster already exists error"
* Add script and `Makefile` target for initialising the azurerm provider
* Add `SKIP_CRD_CREATION` env var for dev loop customisation
* Add persistence of `tfstate` annotation (convert to base64 encoding for better round-tripping)
* Add more context to log output
* Support bool in JSON mapping and add example code for storage account creation to use it
* Add filter in update event handler to exit if Generation hasn't changed between old and new
* Add annotation for LastAppliedGeneration to avoid re-applying via TF on operator startup
