### PR TITLE
Rename imported packages to reflect publisher

### DIFF
--- a/create.go
+++ b/create.go
@@ -9,26 +9,26 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-openapi/spec"
-	"github.com/hashicorp/terraform/configs/configschema"
-	"github.com/hashicorp/terraform/plugin"
+	openapi_spec "github.com/go-openapi/spec"
+	terraform_schema "github.com/hashicorp/terraform/configs/configschema"
+	terraform_plugin "github.com/hashicorp/terraform/plugin"
 	"github.com/zclconf/go-cty/cty"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
+	k8s_apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8s_apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	k8s_apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8s_metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s_schema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8s_wait "k8s.io/apimachinery/pkg/util/wait"
 )
 
-func createCRDsForResources(provider *plugin.GRPCProvider) []GroupVersionFull {
+func createCRDsForResources(provider *terraform_plugin.GRPCProvider) []GroupVersionFull {
 	// Status: This runs but very little validation of the outputted openAPI apecs has been done. Bugs are likely
 
 	tfSchema := provider.GetSchema()
 
 	// Each resource in terraform becomes a openAPI Schema stored in this array
-	resources := []spec.Schema{}
+	resources := []openapi_spec.Schema{}
 
 	// Foreach of the resources create a openAPI spec.
 	// 1. Split terraform computed values into `status` of the CRD as these are unsettable by user
@@ -41,15 +41,15 @@ func createCRDsForResources(provider *plugin.GRPCProvider) []GroupVersionFull {
 		}
 
 		// Create objects for both the spec and status blocks
-		specCRD := spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Type:     spec.StringOrArray{"object"},
+		specCRD := openapi_spec.Schema{
+			SchemaProps: openapi_spec.SchemaProps{
+				Type:     openapi_spec.StringOrArray{"object"},
 				Required: []string{},
 			},
 		}
-		statusCRD := spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Type:     spec.StringOrArray{"object"},
+		statusCRD := openapi_spec.Schema{
+			SchemaProps: openapi_spec.SchemaProps{
+				Type:     openapi_spec.StringOrArray{"object"},
 				Required: []string{},
 			},
 		}
@@ -59,22 +59,22 @@ func createCRDsForResources(provider *plugin.GRPCProvider) []GroupVersionFull {
 		addBlockToSchema(&statusCRD, &specCRD, "root", resource.Block)
 
 		// Add tf operator property
-		statusCRD.Properties["_tfoperator"] = spec.Schema{
-			SchemaProps: spec.SchemaProps{
+		statusCRD.Properties["_tfoperator"] = openapi_spec.Schema{
+			SchemaProps: openapi_spec.SchemaProps{
 				Type: []string{"object"},
-				Properties: map[string]spec.Schema{
-					"provisioningState":     *spec.StringProperty(),
-					"tfState":               *spec.StringProperty(),
-					"lastAppliedGeneration": *spec.StringProperty(),
+				Properties: map[string]openapi_spec.Schema{
+					"provisioningState":     *openapi_spec.StringProperty(),
+					"tfState":               *openapi_spec.StringProperty(),
+					"lastAppliedGeneration": *openapi_spec.StringProperty(),
 				},
 			},
 		}
 
 		// Create a top level schema to represent the resource and add spec and status to it.
-		def := spec.Schema{}
-		def.Type = spec.StringOrArray{"object"}
+		def := openapi_spec.Schema{}
+		def.Type = openapi_spec.StringOrArray{"object"}
 		// Compose these into a top level object
-		def.Properties = map[string]spec.Schema{
+		def.Properties = map[string]openapi_spec.Schema{
 			"spec":   specCRD,
 			"status": statusCRD,
 		}
@@ -92,7 +92,7 @@ func createCRDsForResources(provider *plugin.GRPCProvider) []GroupVersionFull {
 }
 
 // This walks the schema and adds the fields to spec/status based on whether they're computed or not.
-func addBlockToSchema(statusCRD, specCRD *spec.Schema, blockName string, block *configschema.Block) {
+func addBlockToSchema(statusCRD, specCRD *openapi_spec.Schema, blockName string, block *terraform_schema.Block) {
 	for attributeName, attribute := range block.Attributes {
 		// Computer attributes from Terraform map to the `status` block in K8s CRDS
 		if attribute.Computed {
@@ -113,41 +113,41 @@ func addBlockToSchema(statusCRD, specCRD *spec.Schema, blockName string, block *
 	}
 }
 
-func addAttributeToSchema(schema *spec.Schema, attributeName string, attribute *configschema.Attribute) {
+func addAttributeToSchema(schema *openapi_spec.Schema, attributeName string, attribute *terraform_schema.Attribute) {
 	// Convert the type from the TF type to the best matching openAPI Type (recursive for complex types)
 	property := getSchemaForType(attributeName, &attribute.Type)
 	property.Description = attribute.Description
 	// Todo Handle other types
 	if schema.Properties == nil {
-		schema.Properties = map[string]spec.Schema{}
+		schema.Properties = map[string]openapi_spec.Schema{}
 	}
 	schema.Properties[attributeName] = *property
 }
 
-func getSchemaForType(name string, item *cty.Type) *spec.Schema {
+func getSchemaForType(name string, item *cty.Type) *openapi_spec.Schema {
 	// Bulk of mapping from TF Schema -> OpenAPI Schema here.
 	// TF Type reference: https://www.terraform.io/docs/extend/schemas/schema-types.html
 	// Open API Type reference: https://swagger.io/docs/specification/data-models/data-types/
 
-	var property *spec.Schema
+	var property *openapi_spec.Schema
 	// Handle basic types - string, bool, number
 	if item.Equals(cty.String) {
-		property = spec.StringProperty()
+		property = openapi_spec.StringProperty()
 	} else if item.Equals(cty.Bool) {
-		property = spec.BoolProperty()
+		property = openapi_spec.BoolProperty()
 	} else if item.Equals(cty.Number) {
-		property = spec.Float64Property()
+		property = openapi_spec.Float64Property()
 
 		// Handle more complex types - map, set and list
 	} else if item.IsMapType() {
 		mapType := getSchemaForType(name+"mapType", item.MapElementType())
-		property = spec.MapProperty(mapType)
+		property = openapi_spec.MapProperty(mapType)
 	} else if item.IsListType() {
 		listType := getSchemaForType(name+"listType", item.ListElementType())
-		property = spec.ArrayProperty(listType)
+		property = openapi_spec.ArrayProperty(listType)
 	} else if item.IsSetType() {
 		setType := getSchemaForType(name+"setType", item.SetElementType())
-		property = spec.ArrayProperty(setType)
+		property = openapi_spec.ArrayProperty(setType)
 	} else {
 		log.Printf("[Error] Unknown type on attribute. Skipping %v", name)
 	}
@@ -157,12 +157,12 @@ func getSchemaForType(name string, item *cty.Type) *spec.Schema {
 
 // Todo: Check if this type already existing of if simpler way to handle tracking both Kind and Resource
 type GroupVersionFull struct {
-	GroupVersionKind     schema.GroupVersionKind
-	GroupVersionResource schema.GroupVersionResource
+	GroupVersionKind     k8s_schema.GroupVersionKind
+	GroupVersionResource k8s_schema.GroupVersionResource
 }
 
 // k8s stuff
-func installCRDs(resources []spec.Schema, providerName, providerVersion string) []GroupVersionFull {
+func installCRDs(resources []openapi_spec.Schema, providerName, providerVersion string) []GroupVersionFull {
 	clientConfig := getK8sClientConfig()
 	// Tracks all CRDs Installed or preexisting generated from the TF Schema
 	gvArray := make([]GroupVersionFull, 0, len(resources))
@@ -170,14 +170,14 @@ func installCRDs(resources []spec.Schema, providerName, providerVersion string) 
 	crdsToCheckInstalled := []GroupVersionFull{}
 
 	// create the clientset
-	apiextensionsClientSet, err := apiextensionsclientset.NewForConfig(clientConfig)
+	apiextensionsClientSet, err := k8s_apiextensionsclientset.NewForConfig(clientConfig)
 	if err != nil {
 		panic(err)
 	}
 
 	// Only install when required
 	// Todo: Limit to only CRDs for the operator
-	installedCrds, _ := apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
+	installedCrds, _ := apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), k8s_metav1.ListOptions{})
 	installedCrdsMap := map[string]bool{}
 	for _, crd := range installedCrds.Items {
 		installedCrdsMap[crd.Name] = true
@@ -188,7 +188,7 @@ func installCRDs(resources []spec.Schema, providerName, providerVersion string) 
 
 		// K8s uses it's own type system for OpenAPI.
 		// To easily convert lets serialize ours and deserialize it as theirs
-		var jsonSchemaProps apiextensionsv1beta1.JSONSchemaProps
+		var jsonSchemaProps k8s_apiextensionsv1beta1.JSONSchemaProps
 		_ = json.Unmarshal(data, &jsonSchemaProps)
 
 		// Create the names for the CRD
@@ -198,35 +198,35 @@ func installCRDs(resources []spec.Schema, providerName, providerVersion string) 
 		version := providerVersion
 		crdName := resource + "." + groupName
 
-		crd := &apiextensionsv1beta1.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
+		crd := &k8s_apiextensionsv1beta1.CustomResourceDefinition{
+			ObjectMeta: k8s_metav1.ObjectMeta{
 				Name:      crdName,
 				Namespace: "default", // Todo: set namespace appropriately in future...
 			},
-			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Spec: k8s_apiextensionsv1beta1.CustomResourceDefinitionSpec{
 				Group:   groupName,
 				Version: version,
-				Scope:   apiextensionsv1beta1.NamespaceScoped,
-				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Scope:   k8s_apiextensionsv1beta1.NamespaceScoped,
+				Names: k8s_apiextensionsv1beta1.CustomResourceDefinitionNames{
 					Plural: resource,
 					Kind:   kind,
 				},
-				Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				Validation: &k8s_apiextensionsv1beta1.CustomResourceValidation{
 					OpenAPIV3Schema: &jsonSchemaProps,
 				},
-				Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-					Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+				Subresources: &k8s_apiextensionsv1beta1.CustomResourceSubresources{
+					Status: &k8s_apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 				},
 			},
 		}
 
 		gvFull := GroupVersionFull{
-			GroupVersionResource: schema.GroupVersionResource{
+			GroupVersionResource: k8s_schema.GroupVersionResource{
 				Group:    groupName,
 				Resource: resource,
 				Version:  version,
 			},
-			GroupVersionKind: schema.GroupVersionKind{
+			GroupVersionKind: k8s_schema.GroupVersionKind{
 				Group:   groupName,
 				Version: version,
 				Kind:    kind,
@@ -258,13 +258,13 @@ func installCRDs(resources []spec.Schema, providerName, providerVersion string) 
 	return gvArray
 }
 
-func createCustomResourceDefinition(namespace string, clientSet apiextensionsclientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+func createCustomResourceDefinition(namespace string, clientSet k8s_apiextensionsclientset.Interface, crd *k8s_apiextensionsv1beta1.CustomResourceDefinition) (*k8s_apiextensionsv1beta1.CustomResourceDefinition, error) {
 	crdName := crd.ObjectMeta.Name
 	fmt.Printf("Creating CRD %q... ", crdName)
-	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, k8s_metav1.CreateOptions{})
 	if err == nil {
 		fmt.Println("created")
-	} else if apierrors.IsAlreadyExists(err) {
+	} else if k8s_apierrors.IsAlreadyExists(err) {
 		fmt.Println("already exists")
 	} else {
 		fmt.Printf("Failed: %+v\n", err)
@@ -275,12 +275,12 @@ func createCustomResourceDefinition(namespace string, clientSet apiextensionscli
 	return crd, nil
 }
 
-func waitForCRDsToBeInstalled(clientSet apiextensionsclientset.Interface, crds []GroupVersionFull) {
+func waitForCRDsToBeInstalled(clientSet k8s_apiextensionsclientset.Interface, crds []GroupVersionFull) {
 	for _, resource := range crds {
 		crdName := resource.GroupVersionResource.Resource + "." + resource.GroupVersionResource.Group
 		// Wait for CRD creation.
-		err := wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
-			crd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crdName, metav1.GetOptions{})
+		err := k8s_wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
+			crd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crdName, k8s_metav1.GetOptions{})
 			fmt.Printf("Waiting on CRD creation: %q \n", crdName)
 			if err != nil {
 				fmt.Printf("Fail to wait for CRD creation: %+v\n", err)
@@ -289,13 +289,13 @@ func waitForCRDsToBeInstalled(clientSet apiextensionsclientset.Interface, crds [
 			}
 			for _, cond := range crd.Status.Conditions {
 				switch cond.Type {
-				case apiextensionsv1beta1.Established:
-					if cond.Status == apiextensionsv1beta1.ConditionTrue {
+				case k8s_apiextensionsv1beta1.Established:
+					if cond.Status == k8s_apiextensionsv1beta1.ConditionTrue {
 						fmt.Printf("CRD creation confirmed: %q \n", crdName)
 						return true, err
 					}
-				case apiextensionsv1beta1.NamesAccepted:
-					if cond.Status == apiextensionsv1beta1.ConditionFalse {
+				case k8s_apiextensionsv1beta1.NamesAccepted:
+					if cond.Status == k8s_apiextensionsv1beta1.ConditionFalse {
 						fmt.Printf("Name conflict while wait for CRD creation: %s, %+v\n", cond.Reason, err)
 					}
 				}


### PR DESCRIPTION
This PR address #34 - adding a prefix to imported packages to make it clear in the code which dependency the type belongs to.