### PR TITLE
Add terraform reconciler options pattern

### DIFF
--- a/reconcile.go
+++ b/reconcile.go
@@ -250,14 +250,16 @@ func (r *TerraformReconciler) saveTerraformStateValue(ctx context.Context, resou
 		return fmt.Errorf("Error marshalling state: %s", err)
 	}
 
-	stateStr := serializedState
+	var stateBytes []byte
 	if r.cipher != nil {
 		var encryptedState []byte
 		r.cipher.Encrypt(encryptedState, serializedState)
-		stateStr = encryptedState
+		stateBytes = encryptedState
+	} else {
+		stateBytes = serializedState
 	}
 
-	err = unstructured.SetNestedField(resource.Object, string(stateStr), "status", "_tfoperator", "tfState")
+	err = unstructured.SetNestedField(resource.Object, string(stateBytes), "status", "_tfoperator", "tfState")
 	if err != nil {
 		return fmt.Errorf("Error setting tfState property: %s", err)
 	}


### PR DESCRIPTION
@EliiseS just a little PR to show how we could use the options pattern for setting the encryption cipher - what do you think?
I also renamed `encrypter` to `cipher` as `encrypter.decrypt` was kinda annoying me! :P