### PR TITLE
Make encryption env var consistent

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -26,6 +26,10 @@ var (
 	recLog   = ctrl.Log.WithName("reconciler")
 )
 
+const (
+	encryptionKeyEnvVar = "TF_STATE_ENCRYPTION_KEY"
+)
+
 type controller struct {
 	client.Client
 	scheme       *runtime.Scheme
@@ -94,7 +98,7 @@ func setupControllerRuntime(provider *plugin.GRPCProvider, resources []GroupVers
 	}
 
 	var opts []TerraformReconcilerOption
-	if encryptionKey := os.Getenv("ENCRYPTION_KEY"); encryptionKey != "" {
+	if encryptionKey := os.Getenv(encryptionKeyEnvVar); encryptionKey != "" {
 		opts = append(opts, WithAesEncryption(encryptionKey))
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -19,6 +19,11 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
+// TODO: Export from package after refactor
+const (
+	encryptionKeyEnvVar = "TF_STATE_ENCRYPTION_KEY"
+)
+
 var _ = Describe("Azure resource creation via CRD", func() {
 	Context("with respect to resource dependencies", func() {
 		randomString := RandomString(12)
@@ -310,7 +315,7 @@ func RandomString(n int) string {
 }
 
 func EncryptionKeyIsSet() bool {
-	if encryptionKey := os.Getenv("TF_STATE_ENCRYPTION_KEY"); encryptionKey == "" {
+	if encryptionKey := os.Getenv(encryptionKeyEnvVar); encryptionKey == "" {
 		return false
 	}
 	return true


### PR DESCRIPTION
This is just fixing an issue in my previous PR where I had the env var name wrong in the controller. Once we refactor into packages this const can be exported rather than duplicated.