### PR TITLE
Add structure to validate CRDs using TF validation rules v2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -106,3 +106,9 @@ RUN \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl
+
+# Install Ngrok
+RUN \
+    curl -LO https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip \
+    && unzip ./ngrok-stable-linux-amd64.zip \
+    && mv ngrok /usr/local/bin

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ __debug_bin
 
 run.pid
 /certs
+scripts/webhook-configuration.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ __debug_bin
 .env
 
 run.pid
+/certs

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,15 @@ clear-stor:
 test-validation:
 	curl -k POST https://localhost/validate-tf-crd -d @./hack/testwebhookrequest.json -H "Content-Type: application/json"
 
-test-webhook:
+# This deploys the webhook into the current cluster
+deploy-webhook:
 	rm -r ./certs
 	./scripts/gen-certs.sh
 	./scripts/deploy-webhook.sh
+
+hack-testwebhook:
+	curl -k -d @./hack/req-create-valid.json -H 'Content-Type: application/json' https://localhost/validate-tf-crd
+	curl -k -d @./hack/req-create-invalid.json -H 'Content-Type: application/json' https://localhost/validate-tf-crd
 
 devcontainer:
 	@echo "Building devcontainer using tag: $(DEV_CONTAINER_TAG)"

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,14 @@ clear-stor:
 	-kubectl delete -f ./examples/storageAccount.yaml
 	-az storage account delete --name test14tfbop --yes
 
+test-validation:
+	curl -k POST https://localhost/validate-tf-crd -d @./hack/testwebhookrequest.json -H "Content-Type: application/json"
+
+test-webhook:
+	rm -r ./certs
+	./scripts/gen-certs.sh
+	./scripts/deploy-webhook.sh
+
 devcontainer:
 	@echo "Building devcontainer using tag: $(DEV_CONTAINER_TAG)"
 	docker build -f .devcontainer/Dockerfile -t $(DEV_CONTAINER_TAG) ./.devcontainer 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build: lint
 	go build .
 
 run: kind-create terraform-hack-init
+	./scripts/gen-certs.sh
 	# Stop any previously running instance of the operator
 	$(shell [ -f run.pid ] && cat run.pid | xargs kill)
 	# Store the pid of the running instance in run.pid file

--- a/controller.go
+++ b/controller.go
@@ -169,7 +169,7 @@ func (v *tfCRDValidator) Handle(ctx context.Context, req admission.Request) admi
 
 	r := v.tfReconcilers[resource.GetObjectKind().GroupVersionKind().String()]
 	resourceName := "azurerm_" + strings.Replace(resource.GetKind(), "-", "_", -1)
-	schema := r.provider.GetSchema().ResourceTypes[resourceName]
+	schema := r.provider.Plugin.GetSchema().ResourceTypes[resourceName]
 
 	spec, gotSpec, err := unstructured.NestedMap(resource.Object, "spec")
 	if err != nil {
@@ -189,7 +189,7 @@ func (v *tfCRDValidator) Handle(ctx context.Context, req admission.Request) admi
 		admission.Errored(http.StatusBadRequest, fmt.Errorf("Unable to apply spec: %s", statusMessage))
 	}
 
-	valResp := r.provider.ValidateResourceTypeConfig(providers.ValidateResourceTypeConfigRequest{
+	valResp := r.provider.Plugin.ValidateResourceTypeConfig(providers.ValidateResourceTypeConfigRequest{
 		TypeName: resourceName,
 		Config:   *terraformConfig,
 	})

--- a/controller.go
+++ b/controller.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	openapi_spec "github.com/go-openapi/spec"
+	"github.com/hashicorp/terraform/providers"
 	"github.com/lawrencegripper/tfoperatorbridge/tfprovider"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -105,18 +107,21 @@ func setupControllerRuntime(provider *tfprovider.TerraformProvider, resources []
 		opts = append(opts, WithAesEncryption(encryptionKey))
 	}
 
+	gvkToReconcilerMap := make(map[string]*TerraformReconciler)
+
 	for i, gv := range resources {
 		groupVersionKind := gv.GroupVersionKind
 		setupLog.Info("Enabling controller for resource", "kind", gv.GroupVersionKind.Kind)
 		client := mgr.GetClient()
 		schema := schemas[i] // TODO: Assumes schema and resources have the same index, make more reboust
+		reconciler := NewTerraformReconciler(provider, client, schema, opts...)
 		err = ctrl.NewControllerManagedBy(mgr).
 			// Note: Generation Changed Predicate means controller only called when an update is made to spec
 			// or other case causing generation to change
 			For(runtimeObjFromGVK(gv.GroupVersionKind), builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 			Complete(&controller{
 				Client:       client,
-				tfReconciler: NewTerraformReconciler(provider, client, schema, opts...),
+				tfReconciler: reconciler,
 				scheme:       mgr.GetScheme(),
 				gvk:          &groupVersionKind,
 			})
@@ -124,6 +129,7 @@ func setupControllerRuntime(provider *tfprovider.TerraformProvider, resources []
 			setupLog.Error(err, "unable to create controller", "kind", gv.GroupVersionKind.Kind)
 			os.Exit(1)
 		}
+		gvkToReconcilerMap[gv.GroupVersionKind.String()] = reconciler
 	}
 
 	// Todo: Enable webhooks in future
@@ -137,7 +143,7 @@ func setupControllerRuntime(provider *tfprovider.TerraformProvider, resources []
 
 	hookServer := mgr.GetWebhookServer()
 	hookServer.CertDir = "./certs"
-	hookServer.Register("/validate-tf-crd", &webhook.Admission{Handler: &tfCRDValidator{}})
+	hookServer.Register("/validate-tf-crd", &webhook.Admission{Handler: &tfCRDValidator{tfReconcilers: gvkToReconcilerMap}})
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
@@ -148,17 +154,48 @@ func setupControllerRuntime(provider *tfprovider.TerraformProvider, resources []
 
 // tfCRDValidator validates Pods
 type tfCRDValidator struct {
-	Client  client.Client
-	decoder *admission.Decoder
+	Client        client.Client
+	decoder       *admission.Decoder
+	tfReconcilers map[string]*TerraformReconciler
 }
 
 // podValidator admits a pod iff a specific annotation exists.
 func (v *tfCRDValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	resource := unstructured.Unstructured{}
 	err := resource.UnmarshalJSON(req.Object.Raw)
-
 	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
+		panic(err)
+	}
+
+	r := v.tfReconcilers[resource.GetObjectKind().GroupVersionKind().String()]
+	resourceName := "azurerm_" + strings.Replace(resource.GetKind(), "-", "_", -1)
+	schema := r.provider.GetSchema().ResourceTypes[resourceName]
+
+	spec, gotSpec, err := unstructured.NestedMap(resource.Object, "spec")
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("Error retrieving CRD spec: %s", err))
+	}
+	if !gotSpec {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("Error - CRD spec not found"))
+	}
+
+	terraformConfig := r.createEmptyTerraformValueForBlock(schema.Block, "test1")
+	terraformConfig, statusMessage, err := r.mapCRDSpecValuesToTerraformConfig(ctx, schema.Block, terraformConfig, spec)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("Error applying values from the CRD spec to Terraform config: %s", err))
+	}
+	if terraformConfig == nil {
+		// unable to retrieve referenced values - retry later
+		admission.Errored(http.StatusBadRequest, fmt.Errorf("Unable to apply spec: %s", statusMessage))
+	}
+
+	valResp := r.provider.ValidateResourceTypeConfig(providers.ValidateResourceTypeConfigRequest{
+		TypeName: resourceName,
+		Config:   *terraformConfig,
+	})
+
+	if valResp.Diagnostics.HasErrors() {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("Invalid CRD configuration: %w", valResp.Diagnostics.Err()))
 	}
 
 	return admission.Allowed("")

--- a/controller.go
+++ b/controller.go
@@ -155,8 +155,8 @@ func setupControllerRuntime(provider *tfprovider.TerraformProvider, resources []
 // tfCRDValidator validates Pods
 type tfCRDValidator struct {
 	Client        client.Client
-	decoder       *admission.Decoder
 	tfReconcilers map[string]*TerraformReconciler
+	decoder       *admission.Decoder //nolint
 }
 
 // podValidator admits a pod iff a specific annotation exists.
@@ -186,7 +186,7 @@ func (v *tfCRDValidator) Handle(ctx context.Context, req admission.Request) admi
 	}
 	if terraformConfig == nil {
 		// unable to retrieve referenced values - retry later
-		admission.Errored(http.StatusBadRequest, fmt.Errorf("Unable to apply spec: %s", statusMessage))
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("Unable to apply spec: %s", statusMessage))
 	}
 
 	valResp := r.provider.Plugin.ValidateResourceTypeConfig(providers.ValidateResourceTypeConfigRequest{

--- a/examples/resourceGroupInvalid.yaml
+++ b/examples/resourceGroupInvalid.yaml
@@ -1,0 +1,10 @@
+apiVersion: azurerm.tfb.local/valpha1
+kind: resource-group
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: test1rg
+  namespace: default
+spec:
+  location: northEurope
+  # An invalid name for RG
+  name: test-$1.%%

--- a/hack/req-create-invalid.json
+++ b/hack/req-create-invalid.json
@@ -1,0 +1,83 @@
+{
+    "apiVersion": "admission.k8s.io/v1beta1",
+    "kind": "AdmissionReview",
+    "request": {
+        "uid": "8d116e45-c52b-45a6-b136-e42622579a3c",
+        "kind": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "kind": "resource-group"
+        },
+        "resource": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "resource": "resource-groups"
+        },
+        "requestKind": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "kind": "resource-group"
+        },
+        "requestResource": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "resource": "resource-groups"
+        },
+        "name": "test2rg",
+        "namespace": "default",
+        "operation": "CREATE",
+        "userInfo": {
+            "username": "kubernetes-admin",
+            "groups": [
+                "system:masters",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "apiVersion": "azurerm.tfb.local/valpha1",
+            "kind": "resource-group",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"azurerm.tfb.local/valpha1\",\"kind\":\"resource-group\",\"metadata\":{\"annotations\":{},\"name\":\"test2rg\",\"namespace\":\"default\"},\"spec\":{\"location\":\"northEurope\",\"name\":\"test2\"}}\n"
+                },
+                "creationTimestamp": "2020-09-10T06:52:42Z",
+                "generation": 1,
+                "managedFields": [
+                    {
+                        "apiVersion": "azurerm.tfb.local/valpha1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:location": {},
+                                "f:name": {}
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "time": "2020-09-10T06:52:42Z"
+                    }
+                ],
+                "name": "test-2",
+                "namespace": "default",
+                "uid": "7f2b02fe-5a95-4ddc-86e9-6f3390899fb9"
+            },
+            "spec": {
+                "location": "northEurope",
+                "name": "test2rg-invalid-name-for-rg!!."
+            }
+        },
+        "oldObject": null,
+        "dryRun": false,
+        "options": {
+            "kind": "CreateOptions",
+            "apiVersion": "meta.k8s.io/v1"
+        }
+    }
+}

--- a/hack/req-create-valid.json
+++ b/hack/req-create-valid.json
@@ -1,0 +1,83 @@
+{
+    "apiVersion": "admission.k8s.io/v1beta1",
+    "kind": "AdmissionReview",
+    "request": {
+        "uid": "8d116e45-c52b-45a6-b136-e42622579a3c",
+        "kind": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "kind": "resource-group"
+        },
+        "resource": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "resource": "resource-groups"
+        },
+        "requestKind": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "kind": "resource-group"
+        },
+        "requestResource": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "resource": "resource-groups"
+        },
+        "name": "test2rg",
+        "namespace": "default",
+        "operation": "CREATE",
+        "userInfo": {
+            "username": "kubernetes-admin",
+            "groups": [
+                "system:masters",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "apiVersion": "azurerm.tfb.local/valpha1",
+            "kind": "resource-group",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"azurerm.tfb.local/valpha1\",\"kind\":\"resource-group\",\"metadata\":{\"annotations\":{},\"name\":\"test2rg\",\"namespace\":\"default\"},\"spec\":{\"location\":\"northEurope\",\"name\":\"test2\"}}\n"
+                },
+                "creationTimestamp": "2020-09-10T06:52:42Z",
+                "generation": 1,
+                "managedFields": [
+                    {
+                        "apiVersion": "azurerm.tfb.local/valpha1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:location": {},
+                                "f:name": {}
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "time": "2020-09-10T06:52:42Z"
+                    }
+                ],
+                "name": "test2rg",
+                "namespace": "default",
+                "uid": "7f2b02fe-5a95-4ddc-86e9-6f3390899fb9"
+            },
+            "spec": {
+                "location": "northEurope",
+                "name": "test2"
+            }
+        },
+        "oldObject": null,
+        "dryRun": false,
+        "options": {
+            "kind": "CreateOptions",
+            "apiVersion": "meta.k8s.io/v1"
+        }
+    }
+}

--- a/hack/req-update.json
+++ b/hack/req-update.json
@@ -1,0 +1,120 @@
+{
+    "apiVersion": "admission.k8s.io/v1beta1",
+    "kind": "AdmissionReview",
+    "request": {
+        "uid": "15e3cedb-2221-471a-85f2-150bf895f81b",
+        "kind": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "kind": "resource-group"
+        },
+        "resource": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "resource": "resource-groups"
+        },
+        "requestKind": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "kind": "resource-group"
+        },
+        "requestResource": {
+            "group": "azurerm.tfb.local",
+            "version": "valpha1",
+            "resource": "resource-groups"
+        },
+        "name": "test1rg",
+        "namespace": "default",
+        "operation": "UPDATE",
+        "userInfo": {
+            "username": "kubernetes-admin",
+            "groups": [
+                "system:masters",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "apiVersion": "azurerm.tfb.local/valpha1",
+            "kind": "resource-group",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"azurerm.tfb.local/valpha1\",\"kind\":\"resource-group\",\"metadata\":{\"annotations\":{},\"name\":\"test1rg\",\"namespace\":\"default\"},\"spec\":{\"location\":\"northEurope\",\"name\":\"test1\"}}\n"
+                },
+                "creationTimestamp": "2020-09-10T06:51:29Z",
+                "finalizers": [
+                    "tfoperatorbridge.local"
+                ],
+                "generation": 1,
+                "managedFields": [
+                    {
+                        "apiVersion": "azurerm.tfb.local/valpha1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:location": {},
+                                "f:name": {}
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "time": "2020-09-10T06:51:29Z"
+                    },
+                    {
+                        "apiVersion": "azurerm.tfb.local/valpha1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"tfoperatorbridge.local\"": {}
+                                }
+                            }
+                        },
+                        "manager": "__debug_bin",
+                        "operation": "Update",
+                        "time": "2020-09-10T06:51:52Z"
+                    }
+                ],
+                "name": "test1rg",
+                "namespace": "default",
+                "resourceVersion": "3968",
+                "uid": "9c53c3f7-754b-4bae-a34e-218183cd8c15"
+            },
+            "spec": {
+                "location": "northEurope",
+                "name": "test1"
+            }
+        },
+        "oldObject": {
+            "apiVersion": "azurerm.tfb.local/valpha1",
+            "kind": "resource-group",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"azurerm.tfb.local/valpha1\",\"kind\":\"resource-group\",\"metadata\":{\"annotations\":{},\"name\":\"test1rg\",\"namespace\":\"default\"},\"spec\":{\"location\":\"northEurope\",\"name\":\"test1\"}}\n"
+                },
+                "creationTimestamp": "2020-09-10T06:51:29Z",
+                "generation": 1,
+                "name": "test1rg",
+                "namespace": "default",
+                "resourceVersion": "3968",
+                "uid": "9c53c3f7-754b-4bae-a34e-218183cd8c15"
+            },
+            "spec": {
+                "location": "northEurope",
+                "name": "test1"
+            }
+        },
+        "dryRun": false,
+        "options": {
+            "kind": "UpdateOptions",
+            "apiVersion": "meta.k8s.io/v1"
+        }
+    }
+}

--- a/hack/testwebhookrequest.json
+++ b/hack/testwebhookrequest.json
@@ -1,0 +1,1 @@
+todo: fill out

--- a/scripts/deploy-webhook.sh
+++ b/scripts/deploy-webhook.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit
 
 # Todo: Inject ip address of host
 
@@ -17,7 +17,7 @@ webhooks:
     resources:   ["*"]
     scope:       "Namespaced"
   clientConfig:
-    caBundle: $(cat ./../certs/ca.crt | base64 | tr -d '\n')
+    caBundle: $(base64 ./../certs/ca.crt | tr -d '\n')
     url: "https://10.0.1.13/validate-tf-crd"
   admissionReviewVersions: ["v1beta1"]
   sideEffects: None

--- a/scripts/deploy-webhook.sh
+++ b/scripts/deploy-webhook.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+cd "$(dirname "$0")"
+
+# Todo: Inject ip address of host
+
+cat > webhook-configuration.yaml <<EOF
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "terraform.operator.validation"
+webhooks:
+- name: "terraform.operator.validation"
+  rules:
+  - apiGroups:   ["azurerm.tfb.local"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["*"]
+    scope:       "Namespaced"
+  clientConfig:
+    caBundle: $(cat ./../certs/ca.crt | base64 | tr -d '\n')
+    url: "https://10.0.1.13/validate-tf-crd"
+  admissionReviewVersions: ["v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 30
+EOF
+
+kubectl apply -f webhook-configuration.yaml

--- a/scripts/gen-certs.sh
+++ b/scripts/gen-certs.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 cd "$(dirname "$0")"
 
+# Todo: inject ip address of host
+
 if [ -d "../certs" ]; then
     echo "../certs exists so assuming certs gen'd already."
     exit 0
@@ -23,9 +25,14 @@ distinguished_name = req_distinguished_name
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
+subjectAltName = @alt_names
+[req_ext]
+subjectAltName = @alt_names
+[alt_names]
+IP.1 = 10.0.1.13
 EOF
 
 openssl genrsa -out tls.key 2048
-openssl req -new -key tls.key -out tls.csr -subj "/CN=tfbridge.tf.svc" -config tls.conf
+openssl req -new -key tls.key -out tls.csr -subj "/IP=10.0.1.13" -config tls.conf
 openssl x509 -req -in tls.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 100000 -extensions v3_req -extfile tls.conf
 

--- a/scripts/gen-certs.sh
+++ b/scripts/gen-certs.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+cd "$(dirname "$0")"
+
+if [ -d "../certs" ]; then
+    echo "../certs exists so assuming certs gen'd already."
+    exit 0
+fi
+
+set -e
+
+mkdir -p ../certs
+cd ../certs
+
+openssl genrsa -out ca.key 2048
+openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
+
+cat >tls.conf <<EOF
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, serverAuth
+EOF
+
+openssl genrsa -out tls.key 2048
+openssl req -new -key tls.key -out tls.csr -subj "/CN=tfbridge.tf.svc" -config tls.conf
+openssl x509 -req -in tls.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 100000 -extensions v3_req -extfile tls.conf
+


### PR DESCRIPTION
Fixed #8

WIP:
- [x] Hook up Controller runtime with validation webhook (1/2 done)
- [x] Call TF Provider `ValidateResourceTypeConfig` when CRD CRUD operation occurs
- [ ] ~Create integration tests to validate behaviour (note need openssl scripts for cert gen as https required for hooks - https://github.com/open-policy-agent/contrib/blob/master/k8s_node_selector/integration/deploy/deploy.sh)~
- [ ] ~Create deployment YAML and Docker build to test in-cluster~ move to separate issues